### PR TITLE
added suggested gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+**/.*
+**/build
+**/__pycache__
+
+!.gitignore


### PR DESCRIPTION
Hi there!

Just getting set up with your repo, and I haven't made any real number theory additions yet, but I'd recommend including a suggested `.gitignore` file in the repo. If someone who has a local build of your project and is new to git tries to contribute, they may unintentionally push some unwanted files. For example, I assume you don't want things like users' local builds and `__pycache__` folders showing up in your repo. (If, like you said in your talk, you attract some *mathematicians* who could use *programming* practice, this will surely happen. ;-) )

Also, I was not even sure myself which files you're open to letting people change with a pull request, so maybe you could make some changes to the `.gitignore` file yourself to let people know which things you don't want them changing. I noticed that when I build the library locally, some of the files in `dist` were mutated, and I had to do some fiddling to exclude those changes from this PR.